### PR TITLE
Removed chromeframe

### DIFF
--- a/header.php
+++ b/header.php
@@ -12,7 +12,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" <?php language_attributes(); ?>> <!--<![endif]-->
 	<head>
 		<meta charset="<?php bloginfo('charset'); ?>">
-		<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+		<meta http-equiv="X-UA-Compatible" content="IE=edge">
 		<meta name="viewport" content="width=device-width">
 
 		<link rel="profile" href="http://gmpg.org/xfn/11">


### PR DESCRIPTION
Google's Chromeframe has long been discontinued and is not supported or available for download. It can be removed from here.