### PR TITLE
Fix typo

### DIFF
--- a/search.php
+++ b/search.php
@@ -8,7 +8,7 @@
 get_header();
 
 /**
- * determine main column size from actived sidebar
+ * determine main column size from active sidebar
  */
 $main_column_size = bootstrapBasicGetMainColumnSize();
 ?> 


### PR DESCRIPTION
I think this should be 'active' (but maybe 'activated'?).